### PR TITLE
Dev dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 test:
-	json_verify < package.json
+	./node_modules/.bin/jsonlint < package.json
 	./node_modules/.bin/tap tests/*.js
 
 announce:

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "url": "git://github.com/fmarier/node-libravatar.git"
   },
   "devDependencies": {
-    "tap": ">= 0.1.x"
+    "tap": ">= 0.1.x",
+    "jsonlint": ">= 1.3.x"
   },
   "engines": {
     "node": ">=0.4.3"


### PR DESCRIPTION
Hey Francois,

Was just looking through node-libravatar and noticed tap missing - should be in devDependencies.

Then I wondered if jsonlint might be easier for people to install if they can't get yajl-tools.

Anyway, just cherry-pick the first commit if you don't want the 2nd.

Cheers,
Andy
