### PR TITLE
No need for jsonlint since by using 'npm test' it reads package.json which means it has to be valid

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,3 @@
-test:
-	./node_modules/.bin/jsonlint < package.json > /dev/null
-	./node_modules/.bin/tap tests/*.js
-
 announce:
 	interactive-freecode-submit node-libravatar
 

--- a/package.json
+++ b/package.json
@@ -15,14 +15,13 @@
     "url": "git://github.com/fmarier/node-libravatar.git"
   },
   "devDependencies": {
-    "tap": ">= 0.1.x",
-    "jsonlint": ">= 1.3.x"
+    "tap": ">= 0.1.x"
   },
   "engines": {
     "node": ">=0.4.3"
   },
   "scripts": {
-    "test": "make test"
+    "test": "tap tests/*.js"
   },
   "main": "index"
 }


### PR DESCRIPTION
Ok, so I've just gone round in a circle and removed jsonlint completely.

Go to your command line and instead of typing 'make test', just type 'npm test'. What this does is read the package.json file, extract the command 'test' from the 'scripts' section and runs it.

Of course this means that package.json _must_ be valid.

Also, if you want to know why ./node_modules/.bin/tap is now just 'tap' is because npm adds the ./node_modules/.bin/ path to any command in the scripts section of package.json automatically.

Again, very much an optional patch and might help you without having to suppress the jsonlint output. Also, you can always add the 'test' section of the Makefile back in to just be 'npm test'. :)
